### PR TITLE
Support StorageResolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ To write [high-resolution metrics](https://docs.aws.amazon.com/AmazonCloudWatch/
 counter(
   "http.request.count",
   reporter_options: [storage_resolution: 1]
-),
+)
 ```
 
 ### When Data is Sent

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ To write [high-resolution metrics](https://docs.aws.amazon.com/AmazonCloudWatch/
 ```elixir
 counter(
   "http.request.count",
-  reporter_options: [storage_resolution: 1]
+  reporter_options: [storage_resolution: :high]
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ below for posting rules).  For instance:
 
 These metrics are sent to CloudWatch based on the rules described below.
 
-To write [high-resolution metrics](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/publishingMetrics.html#high-resolution-metrics=), supply the `:storage_resolution` option:
+To write [high-resolution metrics](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/publishingMetrics.html#high-resolution-metrics=), supply the `:storage_resolution` option (which can be the default of `:standard` or `:high`):
 
 ```elixir
 counter(

--- a/README.md
+++ b/README.md
@@ -75,6 +75,15 @@ below for posting rules).  For instance:
 
 These metrics are sent to CloudWatch based on the rules described below.
 
+To write [high-resolution metrics](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/publishingMetrics.html#high-resolution-metrics=), supply the `:storage_resolution` option:
+
+```elixir
+counter(
+  "http.request.count",
+  reporter_options: [storage_resolution: 1]
+),
+```
+
 ### When Data is Sent
 
 Cloudwatch has [certain constraints](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/publishingMetrics.html)

--- a/lib/telemetry_metrics_cloudwatch/cache.ex
+++ b/lib/telemetry_metrics_cloudwatch/cache.ex
@@ -235,6 +235,19 @@ defmodule TelemetryMetricsCloudwatch.Cache do
   end
 
   defp get_storage_resolution(reporter_options) do
-    Keyword.get(reporter_options, :storage_resolution, 60)
+    case Keyword.get(reporter_options, :storage_resolution, :standard) do
+      :high ->
+        1
+
+      :standard ->
+        60
+
+      other ->
+        Logger.error(
+          "Could not process storage_resolution #{inspect(other)}. Falling back to default."
+        )
+
+        60
+    end
   end
 end

--- a/lib/telemetry_metrics_cloudwatch/cache.ex
+++ b/lib/telemetry_metrics_cloudwatch/cache.ex
@@ -164,7 +164,8 @@ defmodule TelemetryMetricsCloudwatch.Cache do
           metric_name: extract_string_name(metric) <> ".summary",
           values: measurements,
           dimensions: tags,
-          unit: get_unit(metric.unit)
+          unit: get_unit(metric.unit),
+          storage_resolution: get_storage_resolution(metric.reporter_options)
         ]
       end)
 
@@ -180,7 +181,8 @@ defmodule TelemetryMetricsCloudwatch.Cache do
           metric_name: extract_string_name(metric) <> ".count",
           value: measurement,
           dimensions: tags,
-          unit: "Count"
+          unit: "Count",
+          storage_resolution: get_storage_resolution(metric.reporter_options)
         ]
       end)
 
@@ -196,7 +198,8 @@ defmodule TelemetryMetricsCloudwatch.Cache do
           metric_name: extract_string_name(metric) <> ".sum",
           value: measurement,
           dimensions: tags,
-          unit: get_unit(metric.unit)
+          unit: get_unit(metric.unit),
+          storage_resolution: get_storage_resolution(metric.reporter_options)
         ]
       end)
 
@@ -212,7 +215,8 @@ defmodule TelemetryMetricsCloudwatch.Cache do
           metric_name: extract_string_name(metric) <> ".last_value",
           value: measurement,
           dimensions: tags,
-          unit: get_unit(metric.unit)
+          unit: get_unit(metric.unit),
+          storage_resolution: get_storage_resolution(metric.reporter_options)
         ]
       end)
 
@@ -228,5 +232,9 @@ defmodule TelemetryMetricsCloudwatch.Cache do
     else
       "None"
     end
+  end
+
+  defp get_storage_resolution(reporter_options) do
+    Keyword.get(reporter_options, :storage_resolution, 60)
   end
 end

--- a/lib/telemetry_metrics_cloudwatch/cache.ex
+++ b/lib/telemetry_metrics_cloudwatch/cache.ex
@@ -243,11 +243,7 @@ defmodule TelemetryMetricsCloudwatch.Cache do
         60
 
       other ->
-        Logger.error(
-          "Could not process storage_resolution #{inspect(other)}. Falling back to default."
-        )
-
-        60
+        raise "Unsupported storage_resolution: #{inspect(other)}"
     end
   end
 end

--- a/test/telemetry_metrics_cloudwatch_test.exs
+++ b/test/telemetry_metrics_cloudwatch_test.exs
@@ -275,7 +275,7 @@ defmodule TelemetryMetricsCloudwatchTest do
     test "should respect the storage resolution option" do
       counter =
         Metrics.counter([:aname, :value],
-          reporter_options: [storage_resolution: 1]
+          reporter_options: [storage_resolution: :high]
         )
 
       cache = Cache.push_measurement(%Cache{}, %{value: 112}, %{}, counter)

--- a/test/telemetry_metrics_cloudwatch_test.exs
+++ b/test/telemetry_metrics_cloudwatch_test.exs
@@ -33,7 +33,8 @@ defmodule TelemetryMetricsCloudwatchTest do
                metric_name: "aname.value.count",
                value: 1,
                dimensions: [host: "a host", port: "123"],
-               unit: "Count"
+               unit: "Count",
+               storage_resolution: 60
              ]
     end
 
@@ -57,7 +58,8 @@ defmodule TelemetryMetricsCloudwatchTest do
                metric_name: "aname.value.count",
                value: 1,
                dimensions: [host: "a host", port: "123"],
-               unit: "Count"
+               unit: "Count",
+               storage_resolution: 60
              ]
     end
 
@@ -82,7 +84,8 @@ defmodule TelemetryMetricsCloudwatchTest do
                metric_name: "aname.value.count",
                value: 1,
                dimensions: Enum.take(tvalues, 10),
-               unit: "Count"
+               unit: "Count",
+               storage_resolution: 60
              ]
     end
   end
@@ -99,7 +102,13 @@ defmodule TelemetryMetricsCloudwatchTest do
       {postcache, metrics} = Cache.pop_metrics(cache)
 
       assert metrics == [
-               [metric_name: "aname.value.count", value: 1, dimensions: [], unit: "Count"]
+               [
+                 metric_name: "aname.value.count",
+                 value: 1,
+                 dimensions: [],
+                 unit: "Count",
+                 storage_resolution: 60
+               ]
              ]
 
       assert Cache.metric_count(postcache) == 0
@@ -122,7 +131,8 @@ defmodule TelemetryMetricsCloudwatchTest do
                metric_name: "aname.value.count",
                value: 2,
                dimensions: [],
-               unit: "Count"
+               unit: "Count",
+               storage_resolution: 60
              ]
 
       assert Cache.metric_count(postcache) == 0
@@ -144,7 +154,13 @@ defmodule TelemetryMetricsCloudwatchTest do
       {postcache, metrics} = Cache.pop_metrics(cache)
 
       assert metrics == [
-               [metric_name: "aname.value.sum", value: 233, dimensions: [], unit: "None"]
+               [
+                 metric_name: "aname.value.sum",
+                 value: 233,
+                 dimensions: [],
+                 unit: "None",
+                 storage_resolution: 60
+               ]
              ]
 
       assert Cache.metric_count(postcache) == 0
@@ -168,7 +184,8 @@ defmodule TelemetryMetricsCloudwatchTest do
                metric_name: "aname.value.count",
                value: 1,
                dimensions: [],
-               unit: "Count"
+               unit: "Count",
+               storage_resolution: 60
              ]
     end
 
@@ -189,7 +206,8 @@ defmodule TelemetryMetricsCloudwatchTest do
                metric_name: "aname.value.count",
                value: 1,
                dimensions: [],
-               unit: "Count"
+               unit: "Count",
+               storage_resolution: 60
              ]
     end
 
@@ -215,7 +233,8 @@ defmodule TelemetryMetricsCloudwatchTest do
                metric_name: "aname.value.count",
                value: 2,
                dimensions: [],
-               unit: "Count"
+               unit: "Count",
+               storage_resolution: 60
              ]
 
       assert Cache.metric_count(postcache) == 0
@@ -245,11 +264,34 @@ defmodule TelemetryMetricsCloudwatchTest do
                metric_name: "aname.value.count",
                value: 2,
                dimensions: [],
-               unit: "Count"
+               unit: "Count",
+               storage_resolution: 60
              ]
 
       assert Cache.metric_count(postcache) == 0
       assert Cache.max_values_per_metric(postcache) == 0
+    end
+
+    test "should respect the storage resolution option" do
+      counter =
+        Metrics.counter([:aname, :value],
+          reporter_options: [storage_resolution: 1]
+        )
+
+      cache = Cache.push_measurement(%Cache{}, %{value: 112}, %{}, counter)
+
+      assert Cache.metric_count(cache) == 1
+      assert Cache.max_values_per_metric(cache) == 1
+
+      {_postcache, [metrics]} = Cache.pop_metrics(cache)
+
+      assert metrics == [
+               metric_name: "aname.value.count",
+               value: 1,
+               dimensions: [],
+               unit: "Count",
+               storage_resolution: 1
+             ]
     end
   end
 end


### PR DESCRIPTION
AWS supports high-resolution metrics with 1 second granularity, instead of the default 60 second granularity.

This PR adds support for configuring a metric as high-resolution by passing the option in through `reporter_options`:

```
counter(
  "http.request.count",
  reporter_options: [storage_resolution: :high]
)
```

I've also tested this manually with AWS and confirmed that the metrics are stored with higher granularity.