### PR TITLE
Push metrics on terminate

### DIFF
--- a/lib/telemetry_metrics_cloudwatch.ex
+++ b/lib/telemetry_metrics_cloudwatch.ex
@@ -230,6 +230,7 @@ defmodule TelemetryMetricsCloudwatch do
         :ok
 
       {_, metric_data} ->
+        Logger.debug("#{__MODULE__} flushing metrics")
         Cloudwatch.send_metrics(metric_data, namespace)
         :ok
     end


### PR DESCRIPTION
In AWS Batch, sometimes the application exits normally before the measurements have been pushed to Cloud Watch - the measurements are still in the cache. This PR will push any cached measurements on a graceful shutdown of the supervision tree. It will not push during a brutal kill (terminate callback is not invoked).

Test - we push two metrics - the first is delivered during the normal push interval. The second is delivered by the terminate.

```elixir
iex(3)> {:ok, pid} = Tester.start()
{:ok, #PID<0.334.0>}
iex(4)> 
nil
iex(5)> Tester.push(); GenServer.stop(pid) 

19:25:07.873 [debug] http.request.count[Elixir.Telemetry.Metrics.Counter] received with value 1 and tags []
 
19:25:08.355 [debug] Elixir.TelemetryMetricsCloudwatch.Cloudwatch pushed 1 metrics to cloudwatch in namespace TelemetryMetricsCloudwatch
 
19:25:08.355 [debug] vm.memory.total[Elixir.Telemetry.Metrics.LastValue] received with value 65535 and tags []
 
19:25:08.355 [debug] Elixir.TelemetryMetricsCloudwatch flushing metrics
 
19:25:08.666 [debug] Elixir.TelemetryMetricsCloudwatch.Cloudwatch pushed 1 metrics to cloudwatch in namespace TelemetryMetricsCloudwatch

:ok
```


Started in normal supervision tree:

```elixir
{:ok, _} = Application.ensure_all_started(:hackney)
{:ok, _} = Application.ensure_all_started(:ex_aws)

metrics = [
  counter("http.request.count"),
  last_value("vm.memory.total", unit: :byte)
]

children = [
  {TelemetryMetricsCloudwatch,
   [
     metrics: metrics,
     namespace: "TelemetryMetricsCloudwatch",
     push_interval: :timer.seconds(5)
   ]}
]

opts = [strategy: :one_for_one, name: ExampleApp.Supervisor]
Supervisor.start_link(children, opts)
```

Metrics pushed:

```elixir
:telemetry.execute([:http, :request], %{count: 1, duration: 1}, %{})
:telemetry.execute([:vm, :memory], %{total: 0xFFFF}, %{})
```