### PR TITLE
Update telemetry_metrics to 1.0.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -64,7 +64,7 @@ defmodule TelemetryMetricsCloudwatch.MixProject do
       {:ex_aws_cloudwatch, "~> 2.0"},
       {:ex_doc, "~> 0.28", only: :dev},
       {:credo, "~> 1.6", only: [:dev, :test], runtime: false},
-      {:telemetry_metrics, "~> 0.6"}
+      {:telemetry_metrics, "~> 1.0"}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -13,5 +13,5 @@
   "mime": {:hex, :mime, "2.0.5", "dc34c8efd439abe6ae0343edbb8556f4d63f178594894720607772a041b04b02", [:mix], [], "hexpm", "da0d64a365c45bc9935cc5c8a7fc5e49a0e0f9932a761c55d6c52b142780a05c"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.3.1", "2c54013ecf170e249e9291ed0a62e5832f70a476c61da16f6aac6dca0189f2af", [:mix], [], "hexpm", "2682e3c0b2eb58d90c6375fc0cc30bc7be06f365bf72608804fb9cffa5e1b167"},
   "telemetry": {:hex, :telemetry, "1.2.1", "68fdfe8d8f05a8428483a97d7aab2f268aaff24b49e0f599faa091f1d4e7f61c", [:rebar3], [], "hexpm", "dad9ce9d8effc621708f99eac538ef1cbe05d6a874dd741de2e689c47feafed5"},
-  "telemetry_metrics": {:hex, :telemetry_metrics, "0.6.1", "315d9163a1d4660aedc3fee73f33f1d355dcc76c5c3ab3d59e76e3edf80eef1f", [:mix], [{:telemetry, "~> 0.4 or ~> 1.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "7be9e0871c41732c233be71e4be11b96e56177bf15dde64a8ac9ce72ac9834c6"},
+  "telemetry_metrics": {:hex, :telemetry_metrics, "1.0.0", "29f5f84991ca98b8eb02fc208b2e6de7c95f8bb2294ef244a176675adc7775df", [:mix], [{:telemetry, "~> 0.4 or ~> 1.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "f23713b3847286a534e005126d4c959ebcca68ae9582118ce436b521d1d47d5d"},
 }


### PR DESCRIPTION
This dependency is now at version 1.0. There are no functional changes as per their [changelog](https://github.com/beam-telemetry/telemetry_metrics/blob/main/CHANGELOG.md#100).