### PR TITLE
Implement event filtering on measurements

### DIFF
--- a/lib/telemetry_metrics_cloudwatch/cache.ex
+++ b/lib/telemetry_metrics_cloudwatch/cache.ex
@@ -37,7 +37,7 @@ defmodule TelemetryMetricsCloudwatch.Cache do
         Logger.debug("Ignoring nil value for #{inspect(metric)}")
         cache
 
-      not keep?(metric, metadata) ->
+      not keep?(metric, metadata, measurements) ->
         Logger.debug("Dropping value for #{inspect(metric)}")
         cache
 
@@ -128,10 +128,13 @@ defmodule TelemetryMetricsCloudwatch.Cache do
     end
   end
 
-  defp keep?(%{keep: func}, metadata) when is_function(func, 1),
+  defp keep?(%{keep: func}, metadata, _measurements) when is_function(func, 1),
     do: func.(metadata)
 
-  defp keep?(_metric, _metadata), do: true
+  defp keep?(%{keep: func}, metadata, measurements) when is_function(func, 2),
+    do: func.(metadata, measurements)
+
+  defp keep?(_metric, _metadata, _measurements), do: true
 
   # extract up to 10 tags, and don't include any empty values
   # because cloudwatch won't handle any empty dimensions

--- a/lib/telemetry_metrics_cloudwatch/cache.ex
+++ b/lib/telemetry_metrics_cloudwatch/cache.ex
@@ -37,7 +37,7 @@ defmodule TelemetryMetricsCloudwatch.Cache do
         Logger.debug("Ignoring nil value for #{inspect(metric)}")
         cache
 
-      drop?(metric, metadata) ->
+      not keep?(metric, metadata) ->
         Logger.debug("Dropping value for #{inspect(metric)}")
         cache
 
@@ -128,13 +128,10 @@ defmodule TelemetryMetricsCloudwatch.Cache do
     end
   end
 
-  defp drop?(%{keep: func}, metadata) when is_function(func, 1),
-    do: not func.(metadata)
-
-  defp drop?(%{drop: func}, metadata) when is_function(func, 1),
+  defp keep?(%{keep: func}, metadata) when is_function(func, 1),
     do: func.(metadata)
 
-  defp drop?(_metric, _metadata), do: false
+  defp keep?(_metric, _metadata), do: true
 
   # extract up to 10 tags, and don't include any empty values
   # because cloudwatch won't handle any empty dimensions


### PR DESCRIPTION
- Change `drop?/2` -> to `keep?/2` and remove unnecessary clause

  `:drop` is an option for the metric functions, but the `:keep` and `:drop` functions are rolled up into a single `:keep` field on the metric structs.

- Implement event filtering on measurements

  This was introduced in version `1.1.0` of `telemetry_metrics`.