### PR TITLE
Remove debug logging for non-number metrics

### DIFF
--- a/lib/telemetry_metrics_cloudwatch/cache.ex
+++ b/lib/telemetry_metrics_cloudwatch/cache.ex
@@ -42,12 +42,6 @@ defmodule TelemetryMetricsCloudwatch.Cache do
         cache
 
       is_number(measurement) ->
-        sname = extract_string_name(metric)
-
-        msg =
-          "#{sname}[#{metric.__struct__}] received with value #{measurement} and tags #{inspect(tags)}"
-
-        Logger.debug(msg)
         coalesce(cache, metric, measurement, tags)
 
       true ->


### PR DESCRIPTION
These logs are flooding our log files. Not sure if they are neccessary if everything is OK. Another suggestion would be to change it to `verbose`.