### PR TITLE
perf: sample before sending message

### DIFF
--- a/lib/telemetry_metrics_cloudwatch.ex
+++ b/lib/telemetry_metrics_cloudwatch.ex
@@ -142,7 +142,13 @@ defmodule TelemetryMetricsCloudwatch do
 
     for {event, metrics} <- groups do
       id = {__MODULE__, event, self()}
-      :telemetry.attach(id, event, &__MODULE__.handle_telemetry_event/4, {self(), metrics})
+
+      :telemetry.attach(
+        id,
+        event,
+        &__MODULE__.handle_telemetry_event/4,
+        {self(), metrics, sample_rate}
+      )
     end
 
     state = %Cache{
@@ -166,17 +172,11 @@ defmodule TelemetryMetricsCloudwatch do
 
   @impl true
   def handle_info({:handle_event, measurements, metadata, metrics}, state) do
-    %Cache{sample_rate: sample_rate} = state
-
     newstate =
       Enum.reduce(metrics, state, fn metric, state ->
-        if sample_measurement?(sample_rate) do
-          state
-          |> Cache.push_measurement(measurements, metadata, metric)
-          |> push_check()
-        else
-          state
-        end
+        state
+        |> Cache.push_measurement(measurements, metadata, metric)
+        |> push_check()
       end)
 
     {:noreply, newstate}
@@ -185,8 +185,13 @@ defmodule TelemetryMetricsCloudwatch do
   @impl true
   def handle_info(_message, state), do: {:noreply, state}
 
-  def handle_telemetry_event(_event_name, measurements, metadata, {pid, metrics}),
-    do: Kernel.send(pid, {:handle_event, measurements, metadata, metrics})
+  def handle_telemetry_event(_event_name, measurements, metadata, {pid, metrics, sample_rate}) do
+    if sample_measurement?(sample_rate) do
+      Kernel.send(pid, {:handle_event, measurements, metadata, metrics})
+    end
+
+    :ok
+  end
 
   defp schedule_push_check(%Cache{push_interval: push_interval}),
     do: Process.send_after(self(), :push_check, push_interval)

--- a/lib/telemetry_metrics_cloudwatch.ex
+++ b/lib/telemetry_metrics_cloudwatch.ex
@@ -156,7 +156,6 @@ defmodule TelemetryMetricsCloudwatch do
       namespace: namespace,
       last_run: System.monotonic_time(:second),
       push_interval: push_interval,
-      sample_rate: sample_rate
     }
 
     schedule_push_check(state)

--- a/lib/telemetry_metrics_cloudwatch/cache.ex
+++ b/lib/telemetry_metrics_cloudwatch/cache.ex
@@ -9,7 +9,6 @@ defmodule TelemetryMetricsCloudwatch.Cache do
     :namespace,
     :last_run,
     :push_interval,
-    :sample_rate,
     counters: %{},
     sums: %{},
     last_values: %{},


### PR DESCRIPTION
This moves metric sampling to before the `Kernel.send/2` call, to prevent unnecessary messages being sent.
Also does a bit of cleanup to remove the now unused `sample_rate` field from the `Cache` struct.

Background:

Without this, we had issues with memory use growing unbounded and eventually OOM crashing our application due to the volume of telemetry events our system emits under production load.
After benchmarking, we noticed that changing the sample rate didn't impact memory use, since it was all process mailbox related.
Sampling before sending messages resolved the memory issues and a synthetic benchmark of 1 million messages at a 0.001 sample rate went from 23 MB to 110 KB peak memory use.

#15