### PR TITLE
feat: scale counters based on sample rate

### DIFF
--- a/lib/telemetry_metrics_cloudwatch.ex
+++ b/lib/telemetry_metrics_cloudwatch.ex
@@ -115,6 +115,7 @@ defmodule TelemetryMetricsCloudwatch do
   * `:namespace` - Namespace to use in CloudWatch
   * `:push_interval` - The minimum interval that metrics are guaranteed to be pushed to cloudwatch (in milliseconds)
   * `:sample_rate` - Sampling factor to apply to metrics. 0.0 will deny all events, 1.0 will queue all events.
+  * `:scale_counters` - When true, counter values are scaled by (1/sample_rate) to correct for sampling (defaults to false)
   """
   def start_link(opts) do
     server_opts = Keyword.take(opts, [:name])
@@ -127,16 +128,17 @@ defmodule TelemetryMetricsCloudwatch do
     namespace = Keyword.get(opts, :namespace, "Telemetry")
     push_interval = Keyword.get(opts, :push_interval, 60_000)
     sample_rate = Keyword.get(opts, :sample_rate, 1.0)
+    scale_counters = Keyword.get(opts, :scale_counters, false)
 
     GenServer.start_link(
       __MODULE__,
-      {metrics, namespace, push_interval, sample_rate},
+      {metrics, namespace, push_interval, sample_rate, scale_counters},
       server_opts
     )
   end
 
   @impl true
-  def init({metrics, namespace, push_interval, sample_rate}) do
+  def init({metrics, namespace, push_interval, sample_rate, scale_counters}) do
     Process.flag(:trap_exit, true)
     groups = Enum.group_by(metrics, & &1.event_name)
 
@@ -155,7 +157,9 @@ defmodule TelemetryMetricsCloudwatch do
       metric_names: Map.keys(groups),
       namespace: namespace,
       last_run: System.monotonic_time(:second),
-      push_interval: push_interval
+      push_interval: push_interval,
+      sample_rate: sample_rate,
+      scale_counters: scale_counters
     }
 
     schedule_push_check(state)

--- a/lib/telemetry_metrics_cloudwatch/cache.ex
+++ b/lib/telemetry_metrics_cloudwatch/cache.ex
@@ -9,6 +9,8 @@ defmodule TelemetryMetricsCloudwatch.Cache do
     :namespace,
     :last_run,
     :push_interval,
+    :sample_rate,
+    :scale_counters,
     counters: %{},
     sums: %{},
     last_values: %{},
@@ -180,9 +182,11 @@ defmodule TelemetryMetricsCloudwatch.Cache do
       cache
       |> Map.get(:counters)
       |> Enum.map(fn {{metric, tags}, measurement} ->
+        value = scale_value(measurement, cache.sample_rate, cache.scale_counters)
+
         [
           metric_name: extract_string_name(metric) <> ".count",
-          value: measurement,
+          value: value,
           dimensions: tags,
           unit: "Count",
           storage_resolution: get_storage_resolution(metric.reporter_options)
@@ -249,4 +253,9 @@ defmodule TelemetryMetricsCloudwatch.Cache do
         raise "Unsupported storage_resolution: #{inspect(other)}"
     end
   end
+
+  defp scale_value(value, _sample_rate, nil), do: value
+  defp scale_value(value, _sample_rate, false), do: value
+  defp scale_value(value, sample_rate, true) when sample_rate > 0, do: round(value / sample_rate)
+  defp scale_value(value, _sample_rate, true), do: value
 end


### PR DESCRIPTION
This adds a new `scale_counters` option, defaulting to `false` for backwards compatibility.
When turned on, it uses the `sample_rate` to adjust counter values to account for the unsampled metrics.
It's not and can't be exact, but it at least gets them in the right ballpark.
Also adds back `sample_rate` to the `Cache` struct that I removed in my last PR, since that's used here now.

Background:

I added this so I didn't have to mentally correct numbers in my head when looking at dashboards for HTTP request counts and similar that we use really low sample rates for.

#15