### PR TITLE
feat: add max_heap_size option

### DIFF
--- a/lib/telemetry_metrics_cloudwatch.ex
+++ b/lib/telemetry_metrics_cloudwatch.ex
@@ -116,6 +116,7 @@ defmodule TelemetryMetricsCloudwatch do
   * `:push_interval` - The minimum interval that metrics are guaranteed to be pushed to cloudwatch (in milliseconds)
   * `:sample_rate` - Sampling factor to apply to metrics. 0.0 will deny all events, 1.0 will queue all events.
   * `:scale_counters` - When true, counter values are scaled by (1/sample_rate) to correct for sampling (defaults to false)
+  * `:max_heap_size` - Maximum heap size for the GenServer process (defaults to 0, which means no limit)
   """
   def start_link(opts) do
     server_opts = Keyword.take(opts, [:name])
@@ -129,17 +130,19 @@ defmodule TelemetryMetricsCloudwatch do
     push_interval = Keyword.get(opts, :push_interval, 60_000)
     sample_rate = Keyword.get(opts, :sample_rate, 1.0)
     scale_counters = Keyword.get(opts, :scale_counters, false)
+    max_heap_size = Keyword.get(opts, :max_heap_size, 0)
 
     GenServer.start_link(
       __MODULE__,
-      {metrics, namespace, push_interval, sample_rate, scale_counters},
+      {metrics, namespace, push_interval, sample_rate, scale_counters, max_heap_size},
       server_opts
     )
   end
 
   @impl true
-  def init({metrics, namespace, push_interval, sample_rate, scale_counters}) do
+  def init({metrics, namespace, push_interval, sample_rate, scale_counters, max_heap_size}) do
     Process.flag(:trap_exit, true)
+    Process.flag(:max_heap_size, max_heap_size)
     groups = Enum.group_by(metrics, & &1.event_name)
 
     for {event, metrics} <- groups do

--- a/lib/telemetry_metrics_cloudwatch.ex
+++ b/lib/telemetry_metrics_cloudwatch.ex
@@ -116,7 +116,7 @@ defmodule TelemetryMetricsCloudwatch do
   * `:push_interval` - The minimum interval that metrics are guaranteed to be pushed to cloudwatch (in milliseconds)
   * `:sample_rate` - Sampling factor to apply to metrics. 0.0 will deny all events, 1.0 will queue all events.
   * `:scale_counters` - When true, counter values are scaled by (1/sample_rate) to correct for sampling (defaults to false)
-  * `:max_heap_size` - Maximum heap size for the GenServer process (defaults to 0, which means no limit)
+  * `:max_heap_size` - Maximum heap size (in bytes) for the GenServer process (defaults to 0, which means no limit)
   """
   def start_link(opts) do
     server_opts = Keyword.take(opts, [:name])


### PR DESCRIPTION
This adds a `max_heap_size` option that can be used to crash the process once it hits a memory limit.
Defaults to `0` for backwards compatibility.

Background:

I added this after crashing our app in production, since the whole machine ran out of memory. So now we're running with this set to `8_388_608` to crash this process instead of letting memory use grow until the machine runs out. Basically an extra safeguard, will likely only run into it with 1.0 sample rates and a large volume of telemetry.

#15